### PR TITLE
 Add 'Allow Headers' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.2
+## 08/24/2019
+
+1. [](#improved)
+    * Add 'Allow Headers' option
+
 # v1.0.1
 ## 09/09/2016
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ enabled: true
 routes:
   - '*'
 origins:
+allowHeaders: []
   - '*'
 methods:
   - OPTIONS
@@ -51,6 +52,10 @@ The origin specifies one or multiple URI that may access the site. You might spe
 ### Allow Methods
 
 The method or methods allowed when accessing the site.
+
+### Allow Headers
+
+The headers allowed when accessing the site.
 
 ### Expose Headers
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: CORS
-version: 1.0.1
+version: 1.0.2
 description: Enables and allows to manage CORS (Cross-Origin Resource Sharing) in Grav
 icon: universal-access
 author:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -61,6 +61,15 @@ form:
       validate:
           type: commalist
 
+    allowHeaders:
+      type: array
+      label: Allow Headers
+      size: large
+      help: "Allow the server to receive the specified headers. For example: content-type"
+      default: []
+      value_only: true
+      placeholder_value: content-type
+
     expose:
       type: array
       label: Expose Headers

--- a/cors.php
+++ b/cors.php
@@ -31,6 +31,7 @@ class CorsPlugin extends Plugin
         $routes = (array) $this->config->get('plugins.cors.routes');
         $origins = (array) $this->config->get('plugins.cors.origins');
         $methods = (array) $this->config->get('plugins.cors.methods');
+        $allowHeaders = (array)$this->config->get('plugins.cors.allowHeaders');
         $expose = (array) $this->config->get('plugins.cors.expose');
         $credentials = $this->config->get('plugins.cors.credentials');
 
@@ -62,6 +63,10 @@ class CorsPlugin extends Plugin
 
             if (count($methods)) {
                 header("Access-Control-Allow-Methods: " . implode(', ', $methods));
+            }
+
+            if (count($allowHeaders)) {
+                header("Access-Control-Allow-Headers: " . implode(', ', $allowHeaders));
             }
 
             if (count($expose)) {


### PR DESCRIPTION
I needed to add 
```
content-type: application/json
```
to my REST API.

It made sense to add it to this plugin. 