### PR TITLE
Small PHP 8.2 support fix

### DIFF
--- a/cors.php
+++ b/cors.php
@@ -65,7 +65,7 @@ class CorsPlugin extends Plugin
                 }
             }
 
-            header("Access-Control-Allow-Origin: ${origin}");
+            header("Access-Control-Allow-Origin: {$origin}");
 
             if (count($methods)) {
                 header("Access-Control-Allow-Methods: " . implode(', ', $methods));


### PR DESCRIPTION
Fix `Deprecated: Using ${var} in strings is deprecated, use {$var} instead ` in PHP 8.2